### PR TITLE
Enabling caching instead buffered read and write for BlueFS files

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4243,6 +4243,12 @@ options:
   level: advanced
   default: false
   with_legacy: true
+- name: bluefs_enable_cache
+  type: bool
+  default: false
+- name: bluefs_cache_size
+  type: size
+  default: 64_K
 - name: bluefs_buffered_io
   type: bool
   level: advanced

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2632,6 +2632,31 @@ int64_t BlueFS::_read_envmode(
   return r;
 }
 
+int64_t BlueFS::_read_from_cache(
+  FileReader *h,         ///< [in] read from here
+  uint64_t off,          ///< [in] offset
+  size_t len,            ///< [in] this many bytes
+  bufferlist *outbl,     ///< [out] optional: reference the result here
+  char *out)             ///< [out] optional: or copy it here
+{
+  dout(10) << __func__ << " h " << h
+           << " 0x" << std::hex << off << "~" << len << std::dec
+     << " from " << lock_fnode_print(h->file) << dendl;
+  if (BlueFSCache.cache.find(off) == BlueFSCache.end()) {
+    // if the offset is not in cache, return -ENOENT
+    dout(10) << __func__ << " offset 0x" << std::hex << off
+             << " not found in cache" << dendl;
+    return -ENOENT;
+  }
+
+  BlueFSCache.find(off).copy(out);
+  BlueFSCache.frequency[off]++;
+  dout(10) << __func__ << " read from cache: 0x"
+           << std::hex << BlueFSCache.find(off).length() << std::dec
+           << dendl;
+  return out.length();
+}
+
 int64_t BlueFS::_read(
   FileReader *h,         ///< [in] read from here
   uint64_t off,          ///< [in] offset
@@ -2639,6 +2664,25 @@ int64_t BlueFS::_read(
   bufferlist *outbl,     ///< [out] optional: reference the result here
   char *out)             ///< [out] optional: or copy it here
 {
+
+  if (cct->_conf->bluefs_cache_enabled) {
+    int64_t r = _read_from_cache(h, off, len, outbl, out);
+    if ( r > 0 ) {
+      // if we read something from cache, return it
+      dout(10) << __func__ << " read from cache: 0x"
+               << std::hex << r << std::dec << dendl;
+      return r;
+    } else if (r < 0 && r != -ENOENT) {
+      // if we failed to read from cache, log the error
+      derr << __func__ << " failed to read from cache: " << r << dendl;
+      return r;
+    } else {
+      // if we didn't read anything from cache, proceed with normal read
+      dout(10) << __func__ << " no data in cache, proceeding with normal read"
+               << dendl;
+    }
+  }
+
   auto t0 = mono_clock::now();
   FileReaderBuffer *buf = &(h->buf);
 
@@ -2749,6 +2793,15 @@ int64_t BlueFS::_read(
     t.substr_of(buf->bl, off - buf->bl_off, r);
     t.hexdump(*_dout);
     *_dout << dendl;
+    
+    if (cct->_conf->bluefs_cache_enabled) {
+    // update the cache
+    int r = _update_cache(h, offset, length);
+    if (r < 0) {
+       derr << __func__ << " failed to update cache, error: " << r << dendl;
+       return r;
+     }
+    }
 
     off += r;
     len -= r;
@@ -3935,6 +3988,72 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   int res = _flush_data(h, offset, length, buffered);
   logger->tinc(l_bluefs_flush_lat, mono_clock::now() - t0);
   return res;
+}
+
+int BlueFS::_update_cache(FileWriter *h, uint64_t offset, uint64_t length) {
+    if BlueFSCache.cache.size() < cct->_conf->bluefs_cache_size {
+      // check if the offset exists in the cache
+      if (BlueFSCache.cache.find(offset) == BlueFSCache.cache.end()) {
+        BlueFSCache.cache.insert(offset, bl);
+        BlueFSCache.frequency.insert(offset, 1);
+        dout(20) << __func__ << " offset 0x" << std::hex << offset
+               << " not in cache, adding the buffer to cache" << std::dec << dendl;
+        return 0;
+      }
+      dout(20) << __func__ << " offset 0x" << std::hex << offset
+               << " found in cache, updating bufferlist" << std::dec << dendl;
+      // update the bufferlist in the cache
+      BlueFSCache.cache[offset] = bl; 
+      BlueFSCache.frequency[offset] += 1;
+      dout(20) << __func__ << " frequency of offset 0x" << std::hex << offset
+               << " is now " << BlueFSCache.frequency[offset] << std::dec << dendl;
+      return 0;
+  }
+  int r = _flush_data_in_cache(FileWriter *h);
+  if (r < 0) {
+    derr << __func__ << " failed to flush data in cache, error: " << r << dendl;
+    return r;
+  }
+  dout(20) << __func__ << " successfully flushed data in cache" << dendl;
+  r = _update_cache(h, offset, length);
+  if (r < 0) {
+    derr << __func__ << " failed to update cache, error: " << r << dendl;
+    return r;
+  }
+  dout(20) << __func__ << " successfully updated cache" << dendl;
+  return 0;
+}
+
+int BlueFS::_flush_data_in_cache(FileWriter *h)
+{
+  ceph_assert(ceph_mutex_is_locked(h->lock));
+  ceph_assert(h->file->fnode.ino > 1);
+
+  // TODO: Do we want to flush the complete cache at once?
+  // or should we flush only certain offsets (a configurable parameter)
+
+  // loop over the cache and flush data
+  for (auto& entry : BlueFSCache.cache) {
+    uint64_t offset = entry.first;
+    auto bl = entry.second;
+
+    /*
+    // Check if the bufferlist length is less than the requested length
+    if (bl.length() < h->get_buffer_length()) {
+      dout(20) << __func__ << " bufferlist length is less than requested length, nothing to flush" << dendl;
+      return -EINVAL; // or some other error code
+    }*/
+
+    dout(20) << __func__ << " flushing data in cache for h " << h
+           << " offset 0x" << std::hex << offset
+           << " length 0x" << length << std::dec << dendl;
+    // Flush the data in the cache
+    int r = _flush_data(h, offset, bl.length(), false);
+    if (r < 0) {
+      return r; // return error if flushing fails
+    }
+  }
+  return 0; // return success if all data flushed successfully
 }
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -393,6 +393,15 @@ public:
   };
   using DirRef = ceph::ref_t<Dir>;
 
+  struct Cache {
+    FileRef file;
+    uint64_t offset;
+    std::unordered_map<uint64_t, ceph::buffer::list> cache;
+    std::map<uint64_t, uint64_t> frequency;
+  }
+
+  Cache BlueFSCache;
+
   struct FileWriter {
     MEMPOOL_CLASS_HELPERS();
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
